### PR TITLE
Feature/save plan 8

### DIFF
--- a/src/main/java/com/pj/planjourney/domain/city/repository/CityRepository.java
+++ b/src/main/java/com/pj/planjourney/domain/city/repository/CityRepository.java
@@ -1,0 +1,10 @@
+package com.pj.planjourney.domain.city.repository;
+
+import com.pj.planjourney.domain.city.entity.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CityRepository extends JpaRepository<City, Long> {
+    Optional<City> findByName(String city);
+}

--- a/src/main/java/com/pj/planjourney/domain/plan/contoller/PlanController.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/contoller/PlanController.java
@@ -1,0 +1,24 @@
+package com.pj.planjourney.domain.plan.contoller;
+
+import com.pj.planjourney.domain.plan.dto.CreatePlanRequestDto;
+import com.pj.planjourney.domain.plan.dto.CreatePlanResponseDto;
+import com.pj.planjourney.domain.plan.service.PlanService;
+import com.pj.planjourney.global.common.response.ApiResponse;
+import com.pj.planjourney.global.common.response.ApiResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/plans")
+public class PlanController {
+
+    private final PlanService planService;
+
+    @PostMapping
+    public ApiResponse<CreatePlanResponseDto> savePlan(@RequestHeader("USERID") Long userId,
+                                                       @RequestBody CreatePlanRequestDto request) {
+        CreatePlanResponseDto response = planService.save(userId, request);
+        return new ApiResponse<>(response, ApiResponseMessage.PLAN_DELETED);
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/plan/dto/CreatePlanRequestDto.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/dto/CreatePlanRequestDto.java
@@ -1,0 +1,24 @@
+package com.pj.planjourney.domain.plan.dto;
+
+import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.plandetail.dto.CreatePlanDetailRequestDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreatePlanRequestDto {
+
+    private String title;
+    private String city;
+    private List<CreatePlanDetailRequestDto> planDetails = new ArrayList<>();
+
+    public CreatePlanRequestDto(Plan plan) {
+        this.title = plan.getTitle();
+        this.city = plan.getCity().getName();
+        planDetails = plan.getPlanDetails().stream().map(CreatePlanDetailRequestDto::new).toList();
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/plan/dto/CreatePlanResponseDto.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/dto/CreatePlanResponseDto.java
@@ -1,0 +1,28 @@
+package com.pj.planjourney.domain.plan.dto;
+
+import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.plandetail.dto.CreatePlanDetailResponseDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreatePlanResponseDto {
+    private Long planId;
+    private String title;
+    private String city;
+    private LocalDateTime createdAt;
+    private List<CreatePlanDetailResponseDto> planDetails = new ArrayList<>();
+
+    public CreatePlanResponseDto(Plan plan) {
+        planId = plan.getId();
+        title = plan.getTitle();
+        city = plan.getCity().getName();
+        createdAt = plan.getCreatedAt();
+        planDetails = plan.getPlanDetails().stream().map(CreatePlanDetailResponseDto::new).toList();
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/plan/entity/Plan.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/entity/Plan.java
@@ -3,11 +3,13 @@ package com.pj.planjourney.domain.plan.entity;
 import com.pj.planjourney.domain.city.entity.City;
 import com.pj.planjourney.domain.comment.entity.Comment;
 import com.pj.planjourney.domain.like.entity.Like;
+import com.pj.planjourney.domain.plan.dto.CreatePlanRequestDto;
 import com.pj.planjourney.domain.plandetail.entity.PlanDetail;
-import com.pj.planjourney.domain.user.entity.User;
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
 import com.pj.planjourney.global.common.Timestamped;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -16,6 +18,7 @@ import java.util.List;
 @Entity
 @Getter
 @Table(name = "plans")
+@NoArgsConstructor
 public class Plan extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,18 +31,30 @@ public class Plan extends Timestamped {
 
     private LocalDateTime publishedAt;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    @OneToMany(mappedBy = "plan")
+    private List<UserPlan> userPlans = new ArrayList<>();
+
     @OneToMany(mappedBy = "plan")
     private List<Comment> comments = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(name = "city_id")
     private City city;
+
     @OneToMany(mappedBy = "plan")
     private List<PlanDetail> planDetails = new ArrayList<>();
+
     @OneToMany(mappedBy = "plan")
     private List<Like> likes = new ArrayList<>();
 
+    public Plan(CreatePlanRequestDto request, City city) {
+        this.title = request.getTitle();
+        this.isPublished = false;
+        this.city = city;
+    }
+
+    public void addPlanDetail(PlanDetail planDetail) {
+        planDetails.add(planDetail);
+        planDetail.setPlan(this);
+    }
 }

--- a/src/main/java/com/pj/planjourney/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,7 @@
+package com.pj.planjourney.domain.plan.repository;
+
+import com.pj.planjourney.domain.plan.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}

--- a/src/main/java/com/pj/planjourney/domain/plan/service/PlanService.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/service/PlanService.java
@@ -1,0 +1,59 @@
+package com.pj.planjourney.domain.plan.service;
+
+import com.pj.planjourney.domain.city.entity.City;
+import com.pj.planjourney.domain.city.repository.CityRepository;
+import com.pj.planjourney.domain.plan.dto.CreatePlanRequestDto;
+import com.pj.planjourney.domain.plan.dto.CreatePlanResponseDto;
+import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.plan.repository.PlanRepository;
+import com.pj.planjourney.domain.plandetail.dto.CreatePlanDetailRequestDto;
+import com.pj.planjourney.domain.plandetail.entity.PlanDetail;
+import com.pj.planjourney.domain.plandetail.repository.PlanDetailRepository;
+import com.pj.planjourney.domain.user.entity.User;
+import com.pj.planjourney.domain.user.entity.repository.UserRepository;
+import com.pj.planjourney.domain.userPlan.entity.InvitedStatus;
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
+import com.pj.planjourney.domain.userPlan.repository.UserPlanRepository;
+import com.pj.planjourney.global.common.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.pj.planjourney.global.common.exception.ExceptionCode.CITY_NOT_FOUND;
+import static com.pj.planjourney.global.common.exception.ExceptionCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+    private final UserRepository userRepository;
+    private final CityRepository cityRepository;
+    private final PlanDetailRepository planDetailRepository;
+    private final UserPlanRepository userPlanRepository;
+
+    public CreatePlanResponseDto save(Long userId, CreatePlanRequestDto request) {
+        User user = findUserById(userId);
+        City city = findCityByName(request.getCity());
+
+        Plan plan = planRepository.save(new Plan(request, city));
+        for (CreatePlanDetailRequestDto detailDto : request.getPlanDetails()) {
+            PlanDetail planDetail = detailDto.toEntity(plan);
+            plan.addPlanDetail(planDetail);
+            planDetailRepository.save(planDetail);
+        }
+
+        userPlanRepository.save(new UserPlan(user, plan, InvitedStatus.ACCEPT));
+        return new CreatePlanResponseDto(plan);
+    }
+
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessLogicException(USER_NOT_FOUND));
+    }
+
+    private City findCityByName(String cityName) {
+        return cityRepository.findByName(cityName)
+                .orElseThrow(() -> new BusinessLogicException(CITY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/plandetail/dto/CreatePlanDetailRequestDto.java
+++ b/src/main/java/com/pj/planjourney/domain/plandetail/dto/CreatePlanDetailRequestDto.java
@@ -1,0 +1,37 @@
+package com.pj.planjourney.domain.plandetail.dto;
+
+import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.plandetail.entity.PlanDetail;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class CreatePlanDetailRequestDto {
+
+    private Integer sequence;
+    private LocalDate date;
+    private String placeName;
+    private Double latitude;
+    private Double longitude;
+
+    public PlanDetail toEntity(Plan plan) {
+        return new PlanDetail(
+                sequence,
+                date,
+                placeName,
+                latitude,
+                longitude,
+                plan);
+    }
+
+    public CreatePlanDetailRequestDto(PlanDetail planDetail) {
+        this.sequence = planDetail.getSequence();
+        this.date = planDetail.getDate();
+        this.placeName = planDetail.getPlaceName();
+        this.latitude = planDetail.getLatitude();
+        this.longitude = planDetail.getLongitude();
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/plandetail/dto/CreatePlanDetailResponseDto.java
+++ b/src/main/java/com/pj/planjourney/domain/plandetail/dto/CreatePlanDetailResponseDto.java
@@ -1,0 +1,27 @@
+package com.pj.planjourney.domain.plandetail.dto;
+
+import com.pj.planjourney.domain.plandetail.entity.PlanDetail;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class CreatePlanDetailResponseDto {
+    private Long planDetailId;
+    private Integer sequence;
+    private LocalDate date;
+    private String placeName;
+    private Double latitude;
+    private Double longitude;
+
+    public CreatePlanDetailResponseDto(PlanDetail planDetail) {
+        this.planDetailId = planDetail.getId();
+        this.sequence = planDetail.getSequence();
+        this.date = planDetail.getDate();
+        this.placeName = planDetail.getPlaceName();
+        this.latitude = planDetail.getLatitude();
+        this.longitude = planDetail.getLongitude();
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/plandetail/entity/PlanDetail.java
+++ b/src/main/java/com/pj/planjourney/domain/plandetail/entity/PlanDetail.java
@@ -3,11 +3,13 @@ package com.pj.planjourney.domain.plandetail.entity;
 import com.pj.planjourney.domain.plan.entity.Plan;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "plan_details")
 public class PlanDetail {
 
@@ -20,12 +22,26 @@ public class PlanDetail {
 
     private LocalDate date;
 
-    private String name;
+    private String placeName;
 
     private Double latitude;
 
     private Double longitude;
+
     @ManyToOne
     @JoinColumn(name = "plan_id")
     private Plan plan;
+
+    public PlanDetail(Integer sequence, LocalDate date, String placeName, Double latitude, Double longitude, Plan plan) {
+        this.sequence = sequence;
+        this.date = date;
+        this.placeName = placeName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.plan = plan;
+    }
+
+    public void setPlan(Plan plan) {
+        this.plan = plan;
+    }
 }

--- a/src/main/java/com/pj/planjourney/domain/plandetail/repository/PlanDetailRepository.java
+++ b/src/main/java/com/pj/planjourney/domain/plandetail/repository/PlanDetailRepository.java
@@ -1,0 +1,7 @@
+package com.pj.planjourney.domain.plandetail.repository;
+
+import com.pj.planjourney.domain.plandetail.entity.PlanDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanDetailRepository extends JpaRepository<PlanDetail, Long> {
+}

--- a/src/main/java/com/pj/planjourney/domain/user/entity/User.java
+++ b/src/main/java/com/pj/planjourney/domain/user/entity/User.java
@@ -4,7 +4,7 @@ import com.pj.planjourney.domain.childcomment.entity.ChildComment;
 import com.pj.planjourney.domain.comment.entity.Comment;
 import com.pj.planjourney.domain.follow.entity.Follow;
 import com.pj.planjourney.domain.like.entity.Like;
-import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
 import com.pj.planjourney.global.common.Timestamped;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -28,15 +28,20 @@ public class User extends Timestamped {
     private String nickname;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = false, fetch = FetchType.LAZY)
-    private List<Plan> plans = new ArrayList<>();  // 유저가 삭제되어도 게시글은 남아있다. 이 분분 유저 정보가 없는데 어떻게 처리할지
+    private List<UserPlan> userPlans = new ArrayList<>();  // 유저가 삭제되어도 게시글은 남아있다. 이 분분 유저 정보가 없는데 어떻게 처리할지
+
     @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
     private List<Follow> followers = new ArrayList<>();
+
     @OneToMany(mappedBy = "following", cascade = CascadeType.ALL)
     private List<Follow> followings = new ArrayList<>();
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<ChildComment> childComments = new ArrayList<>();
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Like> likes = new ArrayList<>();
 

--- a/src/main/java/com/pj/planjourney/domain/user/entity/repository/UserRepository.java
+++ b/src/main/java/com/pj/planjourney/domain/user/entity/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.pj.planjourney.domain.user.entity.repository;
+
+
+import com.pj.planjourney.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/entity/InvitedStatus.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/entity/InvitedStatus.java
@@ -1,0 +1,6 @@
+package com.pj.planjourney.domain.userPlan.entity;
+
+public enum InvitedStatus {
+    WAITING,
+    ACCEPT;
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/entity/UserPlan.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/entity/UserPlan.java
@@ -1,0 +1,36 @@
+package com.pj.planjourney.domain.userPlan.entity;
+
+import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "user_plans")
+public class UserPlan {
+
+    @Id
+    @Column(name = "user_plan_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_id")
+    private Plan plan;
+
+    @Enumerated(EnumType.STRING)
+    private InvitedStatus invitedStatus;
+
+    public UserPlan(User user, Plan plan, InvitedStatus invitedStatus) {
+        this.user = user;
+        this.plan = plan;
+        this.invitedStatus = invitedStatus;
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/repository/UserPlanRepository.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/repository/UserPlanRepository.java
@@ -1,0 +1,7 @@
+package com.pj.planjourney.domain.userPlan.repository;
+
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
+}

--- a/src/main/java/com/pj/planjourney/global/common/exception/ExceptionCode.java
+++ b/src/main/java/com/pj/planjourney/global/common/exception/ExceptionCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ExceptionCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"회원를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"회원를 찾을 수 없습니다."),
+    CITY_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 도시를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/pj/planjourney/global/common/response/ApiResponseMessage.java
+++ b/src/main/java/com/pj/planjourney/global/common/response/ApiResponseMessage.java
@@ -9,6 +9,7 @@ public enum ApiResponseMessage {
     USER_RETRIEVED(HttpStatus.OK, "유저 조회에 성공했습니다."),
     USERS_RETRIEVED(HttpStatus.OK, "유저 목록 조회에 성공했습니다."),
     USER_DELETED(HttpStatus.OK, "회원 삭제에 성공했습니다."),
+    PLAN_DELETED(HttpStatus.OK, "일정 생성에 성공했습니다."),
     SUCCESS(HttpStatus.OK,"성공했습니다.");
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 [FEAT] 일정 저장하기

## 📝작업 내용

> 일정 저장 기능을 구현하였습니다.
1. User와 Plan을 다대다 관계로 구현하기 위해 UserPlan 엔티티를 추가하였습니다.
2. 로그인 기능 구현 전이라서, @RequestHeader("USERID") 를 통해 헤더로 유저 id 를 전달받았습니다.

## 💬리뷰 요구사항
코드가 깔끔하다는 느낌은 덜한 것 같습니다. 개선할 수 있는 부분이 있을지 봐주세요.
그리고 오늘 기술매니저님이랑 의존성 관련된 부분 살펴보기로 해서, 멘토링 이후에 수정이 필요한 부분 확인하고, merge 진행해도 좋을 것 같아요.