### PR TITLE
Feature/invite 38

### DIFF
--- a/src/main/java/com/pj/planjourney/domain/plan/service/PlanService.java
+++ b/src/main/java/com/pj/planjourney/domain/plan/service/PlanService.java
@@ -44,7 +44,7 @@ public class PlanService {
             plan.addPlanDetail(planDetail);
             planDetailRepository.save(planDetail);
         }
-        userPlanRepository.save(new UserPlan(user, plan, InvitedStatus.ACCEPT));
+        userPlanRepository.save(new UserPlan(user, plan, InvitedStatus.ACCEPTED));
         return new CreatePlanResponseDto(plan);
     }
 

--- a/src/main/java/com/pj/planjourney/domain/userPlan/controller/UserPlanController.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/controller/UserPlanController.java
@@ -1,0 +1,48 @@
+package com.pj.planjourney.domain.userPlan.controller;
+
+import com.pj.planjourney.domain.userPlan.dto.AcceptInvitePlanRequestDto;
+import com.pj.planjourney.domain.userPlan.dto.InviteFriendsRequestDto;
+import com.pj.planjourney.domain.userPlan.dto.InvitedPlanResponseDto;
+import com.pj.planjourney.domain.userPlan.service.UserPlanService;
+import com.pj.planjourney.global.auth.service.UserDetailsImpl;
+import com.pj.planjourney.global.common.response.ApiResponse;
+import com.pj.planjourney.global.common.response.ApiResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/invites")
+public class UserPlanController {
+
+    private final UserPlanService userPlanService;
+
+    @PostMapping("/{planId}")
+    public ApiResponse<Void> inviteFriendsToPlan(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                 @PathVariable Long planId,
+                                                 @RequestBody InviteFriendsRequestDto request) {
+        userPlanService.invite(userDetails.getUser(), planId, request);
+        return new ApiResponse<>(null, ApiResponseMessage.REQUEST_SENT);
+    }
+
+    @GetMapping
+    public ApiResponse<List<InvitedPlanResponseDto>> getInvitedPlans(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<InvitedPlanResponseDto> response = userPlanService.getInvitedPlans(userDetails.getUser().getId());
+        return new ApiResponse<>(response, ApiResponseMessage.SUCCESS);
+    }
+
+    @PostMapping("/{userPlanId}/accept")
+    public ApiResponse<AcceptInvitePlanRequestDto> acceptInvitePlan(@PathVariable Long userPlanId) {
+        AcceptInvitePlanRequestDto response  = userPlanService.acceptInvitePlan(userPlanId);
+        return new ApiResponse<>(response, ApiResponseMessage.SUCCESS);
+    }
+
+    @PostMapping("/{userPlanId}/reject")
+    public ApiResponse<Void> rejectInvitePlan(@PathVariable Long userPlanId) {
+        userPlanService.rejectInvitePlan(userPlanId);
+        return new ApiResponse<>(null, ApiResponseMessage.SUCCESS);
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/dto/AcceptInvitePlanRequestDto.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/dto/AcceptInvitePlanRequestDto.java
@@ -1,0 +1,16 @@
+package com.pj.planjourney.domain.userPlan.dto;
+
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AcceptInvitePlanRequestDto {
+
+    private Long planId;
+
+    public AcceptInvitePlanRequestDto(UserPlan userPlan) {
+        this.planId = userPlan.getPlan().getId();
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/dto/InviteFriendsRequestDto.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/dto/InviteFriendsRequestDto.java
@@ -1,0 +1,12 @@
+package com.pj.planjourney.domain.userPlan.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class InviteFriendsRequestDto {
+
+    private final List<Long> inviteFriends = new ArrayList<>();
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/dto/InvitedPlanResponseDto.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/dto/InvitedPlanResponseDto.java
@@ -1,0 +1,21 @@
+package com.pj.planjourney.domain.userPlan.dto;
+
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class InvitedPlanResponseDto {
+
+    private Long userPlanId;
+    private Long planId;
+    private String title;
+
+    public InvitedPlanResponseDto(UserPlan userPlan) {
+        this.userPlanId = userPlan.getId();
+        this.planId = userPlan.getPlan().getId();
+        this.title = userPlan.getPlan().getTitle();
+    }
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/entity/InvitedStatus.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/entity/InvitedStatus.java
@@ -1,6 +1,7 @@
 package com.pj.planjourney.domain.userPlan.entity;
 
 public enum InvitedStatus {
-    WAITING,
-    ACCEPT;
+    PENDING,
+    ACCEPTED,
+    REJECTED
 }

--- a/src/main/java/com/pj/planjourney/domain/userPlan/entity/UserPlan.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/entity/UserPlan.java
@@ -33,4 +33,12 @@ public class UserPlan {
         this.plan = plan;
         this.invitedStatus = invitedStatus;
     }
+
+    public void toAccept() {
+        this.invitedStatus = InvitedStatus.ACCEPTED;
+    }
+
+    public void toReject() {
+        this.invitedStatus = InvitedStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/pj/planjourney/domain/userPlan/repository/UserPlanRepository.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/repository/UserPlanRepository.java
@@ -1,7 +1,12 @@
 package com.pj.planjourney.domain.userPlan.repository;
 
+import com.pj.planjourney.domain.userPlan.entity.InvitedStatus;
 import com.pj.planjourney.domain.userPlan.entity.UserPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
+
+    List<UserPlan> findByUserIdAndInvitedStatus(Long userId, InvitedStatus invitedStatus);
 }

--- a/src/main/java/com/pj/planjourney/domain/userPlan/service/UserPlanService.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/service/UserPlanService.java
@@ -1,0 +1,111 @@
+package com.pj.planjourney.domain.userPlan.service;
+
+import com.pj.planjourney.domain.friend.entity.Friend;
+import com.pj.planjourney.domain.friend.repository.FriendRepository;
+import com.pj.planjourney.domain.plan.entity.Plan;
+import com.pj.planjourney.domain.plan.repository.PlanRepository;
+import com.pj.planjourney.domain.user.entity.User;
+import com.pj.planjourney.domain.user.repository.UserRepository;
+import com.pj.planjourney.domain.userPlan.dto.AcceptInvitePlanRequestDto;
+import com.pj.planjourney.domain.userPlan.dto.InviteFriendsRequestDto;
+import com.pj.planjourney.domain.userPlan.dto.InvitedPlanResponseDto;
+import com.pj.planjourney.domain.userPlan.entity.InvitedStatus;
+import com.pj.planjourney.domain.userPlan.entity.UserPlan;
+import com.pj.planjourney.domain.userPlan.repository.UserPlanRepository;
+import com.pj.planjourney.global.common.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.pj.planjourney.global.common.exception.ExceptionCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserPlanService {
+
+    private final UserPlanRepository userPlanRepository;
+    private final PlanRepository planRepository;
+    private final UserRepository userRepository;
+    private final FriendRepository friendRepository;
+
+    /**
+     * 해당 일정으로 친구를 초대하는 메소드
+     *
+     * @param planId 초대할 일정 id
+     * @param request 초대할 친구들 id 정보가 담겨있는 dto
+     */
+    @Transactional
+    public void invite(User user, Long planId, InviteFriendsRequestDto request) {
+        Plan plan = planRepository.findById(planId).orElseThrow();
+
+        if (request.getInviteFriends().isEmpty())
+            throw new BusinessLogicException(FRIEND_NOT_INVITED);
+
+        for (Long friendId : request.getInviteFriends()) {
+            User friend = findUserById(friendId);
+            isFriend(user, friend);
+
+            UserPlan userPlan = new UserPlan(friend, plan, InvitedStatus.PENDING);
+            userPlanRepository.save(userPlan);
+        }
+    }
+
+    /**
+     * 초대받은 일정 목록 조회하는 메소드
+     * 해당 id, plan id 와 title 반환.
+     * 추후 필요한 정보로 변경 예정.
+     *
+     * @param userId 본인 id
+     * @return 초대받은 일정 목록
+     */
+    public List<InvitedPlanResponseDto> getInvitedPlans(Long userId) {
+        List<UserPlan> plans = userPlanRepository.findByUserIdAndInvitedStatus(userId, InvitedStatus.PENDING);
+        return plans.stream().map(this::toInvitedPlanResponseDto).toList();
+    }
+
+    private InvitedPlanResponseDto toInvitedPlanResponseDto(UserPlan userPlan) {
+        return new InvitedPlanResponseDto(userPlan);
+    }
+
+    /**
+     * 일정 편집 초대를 수락하는 메소드
+     *
+     * @param userPlanId 초대받은 일정 정보 id
+     * @return 해당 일정 id 반환
+     */
+    @Transactional
+    public AcceptInvitePlanRequestDto acceptInvitePlan(Long userPlanId) {
+        UserPlan userPlan = findUserPlanById(userPlanId);
+        userPlan.toAccept();
+        return new AcceptInvitePlanRequestDto(userPlan);
+    }
+
+    /**
+     * 알정 편집 초대를 거절하는 메소드
+     *
+     * @param userPlanId 초대받은 일정 정보 id
+     */
+    @Transactional
+    public void rejectInvitePlan(Long userPlanId) {
+        UserPlan userPlan = findUserPlanById(userPlanId);
+        userPlan.toReject();
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessLogicException(USER_NOT_FOUND));
+    }
+
+    private void isFriend(User user, User friend) {
+        Friend findFriend = friendRepository.findByUserAndFriend(user, friend);
+        if (findFriend == null) throw new BusinessLogicException(FRIEND_NOT_FOUND);
+    }
+
+    private UserPlan findUserPlanById(Long userPlanId) {
+        return userPlanRepository.findById(userPlanId)
+                .orElseThrow(() -> new BusinessLogicException(REQUEST_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/pj/planjourney/domain/userPlan/service/UserPlanService.java
+++ b/src/main/java/com/pj/planjourney/domain/userPlan/service/UserPlanService.java
@@ -78,6 +78,8 @@ public class UserPlanService {
     @Transactional
     public AcceptInvitePlanRequestDto acceptInvitePlan(Long userPlanId) {
         UserPlan userPlan = findUserPlanById(userPlanId);
+        isPending(userPlan);
+
         userPlan.toAccept();
         return new AcceptInvitePlanRequestDto(userPlan);
     }
@@ -90,6 +92,8 @@ public class UserPlanService {
     @Transactional
     public void rejectInvitePlan(Long userPlanId) {
         UserPlan userPlan = findUserPlanById(userPlanId);
+        isPending(userPlan);
+
         userPlan.toReject();
     }
 
@@ -106,6 +110,11 @@ public class UserPlanService {
     private UserPlan findUserPlanById(Long userPlanId) {
         return userPlanRepository.findById(userPlanId)
                 .orElseThrow(() -> new BusinessLogicException(REQUEST_NOT_FOUND));
+    }
+
+    private void isPending(UserPlan userPlan) {
+        if (userPlan.getInvitedStatus() != InvitedStatus.PENDING)
+            throw new BusinessLogicException(RESPONSE_ALREADY);
     }
 
 }

--- a/src/main/java/com/pj/planjourney/global/common/exception/ExceptionCode.java
+++ b/src/main/java/com/pj/planjourney/global/common/exception/ExceptionCode.java
@@ -10,7 +10,11 @@ public enum ExceptionCode {
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구요청을 찾을 수 없습니다."),
     CITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 도시를 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "선택한 알림을 찾을 수 없습니다."),
-    SENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청자를 찾을 수 없습니다.");
+    SENDER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청자를 찾을 수 없습니다."),
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 친구가 아닙니다."),
+    FRIEND_NOT_INVITED(HttpStatus.NOT_FOUND, "초대할 친구를 선택하세요."),
+    RESPONSE_ALREADY(HttpStatus.NOT_FOUND, "이미 응답이 처리되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용

> 일정 편집방으로 친구 초대하기

- 친구 초대하기 기능

  - 친구 목록 조회 api 는 존재하기 때문에, 따로 추가하지 않았습니다. 친구 목록에서 친구 선택해서 해당 api로 초대하면 될 것 같아요.
  - notifications 테이블에 넣는건 일단 제외. 알림 기능 구현 완료 후, 해당 테이블에 알림 넣는 코드 추가할게요

- 초대받은 목록 조회

  - 어떤 응답값이 필요할지 몰라서 일단 해당 userPlanId, 그리고 plan id 와 title 를 반환하는데, 나중에 프론트랑 상의해서 수정 필요할수도 있을 것 같아요.

- 초대 수락, 거절 기능. 

  - 지금 초대 상태가 PENDING, ACCEPTED, REJECTED 이렇게 3개인데, 친구 초대하면 PENDING 상태, 수락하면 ACCEPTED, 거절하면 REJECTED 로 변경됩니다. (그냥 내 일정 저장할 때는 ACCEPTED 상태로 저장됨)
  - 수락, 거절은 PENDING 상태일때만 가능하도록 했어요.
  - 추가로, 내 일정 불러오기 api 에서는 초대 상태가 ACCEPTED 인 것만 불러오면 될 것 같아요.

## 💬리뷰 요구사항

