### PR TITLE
fix : client header에 token 값 접근 허용

### DIFF
--- a/src/main/java/com/pj/planjourney/global/config/WebConfig.java
+++ b/src/main/java/com/pj/planjourney/global/config/WebConfig.java
@@ -11,6 +11,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOriginPatterns("*")
                 .allowedMethods("*")
+                .allowedHeaders("*")
+                .exposedHeaders("Authorization", "RefreshToken")
                 .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #9

## 📝작업 내용

> CORS 설정을 통한 client 측 header 접근 허용했습니다.

## 💬리뷰 요구 사항

> client 측에서 header 에 있는 token 값 접근이 안되어서  설정을 추가하였는데
>배포 서버에서 이 방법으로 해결이 안될 시 CORS 설정을 다르게 해야 할 거 같습니다.